### PR TITLE
Rename package to blackboard-themepack and update submit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "blackboard-theme",
-  "displayName": "Blackboard Theme",
+  "name": "blackboard-themepack",
+  "displayName": "Blackboard Theme Pack",
   "description": "Classic blackboard aesthetics for night coding - chalk on slate with electric blue accents",
   "version": "0.0.1",
   "publisher": "gesslar",
@@ -11,7 +11,7 @@
   "scripts": {
     "watch": "npx @gesslar/aunty@latest build -wo ./dist ./themes/src/*.yaml",
     "build": "vsce package --skip-license",
-    "submit": "vsce publish"
+    "submit": "xdg-open https://marketplace.visualstudio.com/manage/publishers/gesslar"
   },
   "categories": [
     "Themes"


### PR DESCRIPTION
Updated package name to "blackboard-themepack" and display name to "Blackboard Theme Pack" to better reflect that this is a collection of themes rather than a single theme. Also modified the submit script to open the VSCode marketplace publisher management page instead of directly publishing via vsce.