### PR TITLE
Update submit script to run build first

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "watch": "npx @gesslar/aunty@latest build -wo ./dist ./themes/src/*.yaml",
     "build": "vsce package --skip-license",
-    "submit": "xdg-open https://marketplace.visualstudio.com/manage/publishers/gesslar"
+    "submit": "npm run build && xdg-open https://marketplace.visualstudio.com/manage/publishers/gesslar"
   },
   "categories": [
     "Themes"


### PR DESCRIPTION
Updated the `submit` script in package.json to automatically build the package before opening the marketplace management page. This ensures that the latest version is built before submission, streamlining the release process.